### PR TITLE
Upgrade "midi" dependency and unbreak the build on the newer node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Carlos Rodriguez",
   "license": "MIT",
   "dependencies": {
-    "midi": "~0.6.0",
+    "midi": "~0.9.5",
     "optimist": "~0.3.4",
     "colors": "~0.6.0-1"
   }


### PR DESCRIPTION
Thanks for the nice tool, the referenced "midi" dependency was broken on v7.4.0 and I figured out just upgrading the dependency will fix the issue so tried that locally and it worked and liked to save your time by doing the upgrade here also. Cheers!

```
> midi@0.6.0 install /usr/local/lib/node_modules/lsmidi/node_modules/midi
> node-gyp rebuild

  CXX(target) Release/obj.target/midi/src/node-midi.o
In file included from ../src/node-midi.cpp:8:
../src/lib/RtMidi/RtMidi.cpp:473:26: warning: implicit conversion of NULL constant to 'MIDIEntityRef'
      (aka 'unsigned int') [-Wnull-conversion]
  MIDIEntityRef entity = NULL;
                ~~~~~~   ^~~~
                         0

...
...
```